### PR TITLE
Fix bug in beta/mint-rt-burn.tapscript: misplaced DUP

### DIFF
--- a/beta/mint-rt-burn.tapscript
+++ b/beta/mint-rt-burn.tapscript
@@ -28,9 +28,9 @@ OP_INSPECTOUTPUTASSET
 // check that the asset is explicit
 <1>
 OP_EQUALVERIFY
+OP_DUP  // save asset for later use
 // check that the asset is equal to $lbtcAsset
 <$lbtcAsset>
-OP_DUP  // save $lbtcAsset for later use
 OP_EQUALVERIFY
 
 // Check that "Transaction contains two or three outputs"


### PR DESCRIPTION
Reviewed `beta/mint-rt-burn.tapscript` and noticed a bug - because of incorrect place for OP_DUP, the check for `$lbtcAsset` was not performed