### PR TITLE
fuji.ionio.json: missing OP_DROP after CSV

### DIFF
--- a/artifacts/alpha/fuji.ionio.json
+++ b/artifacts/alpha/fuji.ionio.json
@@ -65,6 +65,7 @@
       "asm": [
         "$expirationTimeout",
         "OP_CHECKSEQUENCEVERIFY",
+        "OP_DROP",
 
         "OP_0",
         "OP_INSPECTOUTPUTASSET",


### PR DESCRIPTION
Modify the artifact according to #14 

@tiero please review